### PR TITLE
Update PHP_CodeSniffer link to new official repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ composer require --dev hanaboso/php-check-utils
 
 CodeSniffer
 -----------
-* PHP_CodeSniffer docs: https://github.com/squizlabs/PHP_CodeSniffer
+* PHP_CodeSniffer docs: https://github.com/PHPCSStandards/PHP_CodeSniffer
 * Slevomat Coding Standard docs: https://github.com/slevomat/coding-standard/
 * run PHP_CodeSniffer
 ```bash
@@ -38,7 +38,7 @@ CodeSniffer
 
 CodeFixer
 ---------
-* PHP_CodeSniffer docs: https://github.com/squizlabs/PHP_CodeSniffer
+* PHP_CodeSniffer docs: https://github.com/PHPCSStandards/PHP_CodeSniffer
 * run PHP_CodeSnifferFixer
 ```bash
 ./vendor/bin/phpcbf --standard=./ruleset.xml -p src/ tests/


### PR DESCRIPTION
The PHP_CodeSniffer project has moved to a new official home under the [PHPCSStandards](https://github.com/PHPCSStandards/) organisation (see [squizlabs/PHP_CodeSniffer#3932](https://github.com/squizlabs/PHP_CodeSniffer/issues/3932)).

The old repository at `squizlabs/PHP_CodeSniffer` is no longer maintained. This PR updates the links in the README to point to the new repository: https://github.com/PHPCSStandards/PHP_CodeSniffer