### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ composer require --dev hanaboso/php-check-utils
 
 CodeSniffer
 -----------
-* PHP_CodeSniffer docs: https://github.com/squizlabs/PHP_CodeSniffer
+* PHP_CodeSniffer docs: https://github.com/PHPCSStandards/PHP_CodeSniffer
 * Slevomat Coding Standard docs: https://github.com/slevomat/coding-standard/
 * run PHP_CodeSniffer
 ```bash
@@ -38,7 +38,7 @@ CodeSniffer
 
 CodeFixer
 ---------
-* PHP_CodeSniffer docs: https://github.com/squizlabs/PHP_CodeSniffer
+* PHP_CodeSniffer docs: https://github.com/PHPCSStandards/PHP_CodeSniffer
 * run PHP_CodeSnifferFixer
 ```bash
 ./vendor/bin/phpcbf --standard=./ruleset.xml -p src/ tests/


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932